### PR TITLE
Adding Renew Functionality for deposit accounts

### DIFF
--- a/IndividualLendingGeneralJavaScript/IndivLendHome.html
+++ b/IndividualLendingGeneralJavaScript/IndivLendHome.html
@@ -926,7 +926,7 @@ $(document).ready(function() {
 					<td style="text-align:right;vertical-align:bottom;width:50px;">&nbsp;</td>
 					<td valign="top">
 						<label for="commencementDate">{{=$ctx.doI18N("label.commencementDate")}}</label>
-						<input id="commencementDate" name="commencementDate" title="" type="text" class="datepickerfield" value="{{=$ctx.globalDate(commencementDate)}}" />
+						<input id="commencementDate" name="commencementDate" title="" type="text" class="datepickerfield" value="{{=$ctx.globalDate(projectedCommencementDate)}}" />
 						<label for="externalId">{{=$ctx.doI18N("form.label.deposit.externalId")}}</label>
 						<input id="externalId" name="externalId" title="" type="text" value="{{=externalId}}" />
 					</td>
@@ -980,11 +980,11 @@ $(document).ready(function() {
 						</td>
 						<td>
 							{{#if interestCompoundingAllowed}}
-							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" checked=checked /><br /><br />
-							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" />
+							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" checked=checked onClick="updateCheckbox()"/><br /><br />
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" disabled="disabled"/>
 							{{#else}}
-							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" /><br /><br />
-							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked />
+							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" onClick="updateCheckbox()"/><br /><br />
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked disabled="disabled"/>
 							{{/if}}
 						</td>
 					</tr>
@@ -1064,6 +1064,143 @@ $(document).ready(function() {
 {{/if}}
 {{/each}}
 </select>
+</form>
+</script>
+
+<script id="renewDepositFormTemplate" type="text/x-jquery-tmpl">
+<form id="entityform">
+    <div id="formerrors"></div>
+
+	<input type="hidden" id="clientId" name="clientId" value="{{=clientId}}" />
+	<input type="hidden" id="dateFormat" name="dateFormat" value="dd MMMM yyyy" />
+	<input type="hidden" id="locale" name="locale" value="{{=$ctx.currentLocale()}}" />
+
+	<fieldset>
+		<legend>{{=$ctx.doI18N("form.legend.deposit.information")}}</legend>
+		<div>
+			<table id="productdetails">
+				<tr>
+					<td valign="top">
+
+						<label for="clientname">{{=$ctx.doI18N("form.label.deposit.applicant")}}</label>
+						<input id="clientname" name="clientName" title="" type="text" value="{{=clientName}}" disabled="disabled" />
+
+						<label for="productId">{{=$ctx.doI18N("form.label.product.dropdown")}}</label>
+						<select name="productId" id="productId">
+							<option value="-1">{{=$ctx.doI18N("form.option.product.dropdown.first.choice")}}</option>
+							{{#each productOptions}}
+							{{#if $ctx.number($parent.parent.data.productId)===$ctx.number(id)}}
+							<option value="{{=$ctx.number(id)}}" selected="selected">{{=name}}</option>
+							{{#else}}
+							<option value="{{=$ctx.number(id)}}">{{=name}}</option>
+							{{/if}}
+							{{/each}}
+						</select>
+					</td>
+					<td style="text-align:right;vertical-align:bottom;width:50px;">&nbsp;</td>
+					<td valign="top">
+						<label for="commencementDate">{{=$ctx.doI18N("label.commencementDate")}}</label>
+						<input id="commencementDate" name="commencementDate" title="" type="text" class="datepickerfield" value="{{=$ctx.globalDate(maturedOn)}}" />
+						<label for="externalId">{{=$ctx.doI18N("form.label.deposit.externalId")}}</label>
+						<input id="externalId" name="externalId" title="" type="text" value="{{=externalId}}" />
+					</td>
+				</tr>
+			</table>
+		</div>
+	</fieldset>
+	<fieldset>
+		<legend>{{=$ctx.doI18N("form.legend.deposit.product.deposit.terms")}}</legend>
+			<table>
+			<tr>
+				<td valign="top" style="padding-right: 5px; border-right: 1px solid;">
+					<table>
+						<tr>
+							<td>{{=$ctx.doI18N("form.label.deposit.product.deposit.amount")}}</td>
+							<td>
+								<input id="deposit" name="deposit" title="" type="text" value="{{=$ctx.decimal(actualMaturityAmount, currency.decimalPlaces)}}" style="width: 125px;" />
+								<input id="currencyCode" name="currencyCode" title="" type="text" value="{{=currency.code}}" style="width: 40px;" disabled="disabled" />
+							</td>
+						</tr>
+						<tr>
+							<td>{{=$ctx.doI18N("form.label.deposit.product.tenure")}}</td>
+							<td>
+								<input id="tenureInMonths" name="tenureInMonths" title="" type="text" value="{{=$ctx.number(tenureInMonths)}}" style="width: 50px;" />
+							</td>
+						</tr>
+					<tr>
+						<td>{{=$ctx.doI18N("form.label.deposit.product.canRenew")}}</td>
+						<td>
+							{{#if renewalAllowed}}
+							<input type="checkbox" id="renewalAllowed" name="renewalAllowed" title="" style="width: 125px;" checked=checked />
+							{{#else}}
+							<input type="checkbox" id="renewalAllowed" name="renewalAllowed" title="" style="width: 125px;" />
+							{{/if}}
+						</td>
+					</tr>
+					<tr>
+						<td>{{=$ctx.doI18N("form.label.deposit.product.canPreClose")}}</td>
+						<td>
+							{{#if preClosureAllowed}}
+							<input type="checkbox" id="preClosureAllowed" name="preClosureAllowed" title="" style="width: 125px;" checked=checked />
+							{{#else}}
+							<input type="checkbox" id="preClosureAllowed" name="preClosureAllowed" title="" style="width: 125px;" />
+							{{/if}}
+						</td>
+					</tr>
+					<tr>
+						<td>
+							{{=$ctx.doI18N("form.label.deposit.product.isCompoundingAllowed")}}<br/><br />
+							{{=$ctx.doI18N("form.label.deposit.product.isInterestWithdrawable")}}
+						</td>
+						<td>
+							{{#if interestCompoundingAllowed}}
+							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" checked=checked onClick="updateCheckbox()"/><br /><br />
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" disabled="disabled"/>
+							{{#else}}
+							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" onClick="updateCheckbox()"/><br /><br />
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked disabled="disabled"/>
+							{{/if}}
+						</td>
+					</tr>
+					</table>
+				</td>
+
+				<!-- interest details cell -->
+				<td valign="top" style="padding-left: 5px; padding-right: 5px; border-right: 1px solid;">
+					<table>
+						<tr>
+							<td>{{=$ctx.doI18N("form.label.deposit.product.nominal.interestrate")}}</td>
+							<td>
+								<input id="maturityInterestRate" name="maturityInterestRate" title="" type="text" value="{{=$ctx.decimal(maturityInterestRate, 4)}}" style="width: 60px;" />
+							</td>
+						</tr>
+					<tr>
+						<td>{{=$ctx.doI18N("form.label.deposit.product.preClosureInterestRate")}}</td>
+						<td>
+							<input id="preClosureInterestRate" name="preClosureInterestRate" title="" style="width: 125px;" value="{{=$ctx.decimal(preClosureInterestRate,4)}}"/>
+						</td>
+					</tr>
+						<tr>
+							<td>{{=$ctx.doI18N("form.label.deposit.product.interest.compounding.every")}}</td>
+							<td>
+								<input id="interestCompoundedEvery" name="interestCompoundedEvery" title="" type="text" value="{{=$ctx.number(interestCompoundedEvery)}}" style="width: 50px;" />
+								
+								<select name="interestCompoundedEveryPeriodType" id="interestCompoundedEveryPeriodType"  title="" style="width: 121px;">
+								{{#each interestCompoundedEveryPeriodTypeOptions}}
+								{{#if $ctx.number($parent.parent.data.interestCompoundedEveryPeriodType.id)===$ctx.number(id)}}
+									<option value="{{=$ctx.number(id)}}" selected="selected">{{=value}}</option>
+								{{#else}}
+									<option value="{{=$ctx.number(id)}}">{{=value}}</option>
+								{{/if}}
+        						{{/each}}
+  								</select>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</fieldset>
 </form>
 </script>
 
@@ -1379,6 +1516,16 @@ $(document).ready(function() {
 </div>
 {{/if}}
 
+{{#if $ctx.numberGreaterThanZero(maturedDepositAccountsCount)}}
+<div class="row">
+	<span class="longrowlabel">{{=$ctx.doI18N("label.matured")}} ({{=$ctx.number(maturedDepositAccountsCount)}}):</span>
+	<span class="rowvalue">
+	{{#each maturedDepositAccounts}}
+		<span class="depositaccount"><a href="unknown.html" onclick="showDepositAccount({{=id}}, '{{=productName}}');return false ;" >{{=productName}}: &#35;{{=id}}</a></span>
+	{{/each}}
+	</span>
+</div>
+{{/if}}
 {{#if $ctx.numberGreaterThanZero(closedDepositAccountsCount)}}
 <div class="row">
 	<span class="longrowlabel">{{=$ctx.doI18N("label.closed")}} ({{=$ctx.number(closedDepositAccountsCount)}}):</span>
@@ -1596,6 +1743,11 @@ $(document).ready(function() {
 		{{/if}}
 		{{/if}}
 
+		{{#if undoApprovalAllowed}}
+		{{#if renewelAllowed}}
+		<button id="renewbtn{{=$parent.parent.parent.parent.data.id}}" class="renewdepositaccount">Renew </button>
+		{{/if}}
+		{{/if}}
 		{{#if pendingApproval}}
 		<button id="deletebtn{{=$parent.parent.parent.data.id}}" class="deletedepositapplication">Delete</button>
 		{{/if}}
@@ -1646,10 +1798,13 @@ $(document).ready(function() {
 			<span class="longrowlabel">{{=$ctx.doI18N("label.client.account.loan.product")}}</span>
 			<span class="rowvalue">{{=productName}}</span>
 		</div>
+
+	{{#if externalId}}
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.client.account.loan.externalid")}}</span>
 			<span class="rowvalue">{{=externalId}}</span>
 		</div>
+	{{/if}}
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.client.account.loan.currency")}}</span>
 			<span class="rowvalue">{{=currency.name}}</span>
@@ -1658,17 +1813,40 @@ $(document).ready(function() {
 			<span class="longrowlabel">{{=$ctx.doI18N("label.deposit")}}</span>
 			<span class="rowvalue">{{=$ctx.moneyFormatted(currency, deposit)}}</span>
 		</div>
+	{{#if projectedInterestAccrued}}
+		<div class="row">
+			<span class="longrowlabel">{{=$ctx.doI18N("label.projectedInterestAccrued")}}</span>
+			<span class="rowvalue">{{=$ctx.moneyFormatted(currency, projectedInterestAccrued)}}</span>
+		</div>
+	{{/if}}
+	{{#if actualInterestAccrued}}
+	{{#if closedonDate}}
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.actualInterestAccrued")}}</span>
 			<span class="rowvalue">{{=$ctx.moneyFormatted(currency, actualInterestAccrued)}}</span>
 		</div>
+	{{/if}}
+	{{/if}}
+	{{#if $ctx.decimal(interestPaid, 2)>0}}
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.interestPaid")}}</span>
 			<span class="rowvalue">{{=$ctx.moneyFormatted(currency, interestPaid)}}</span>
 		</div>
+	{{/if}}
+	{{#if actualMaturityAmount}}
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.actualMaturityAmount")}}</span>
 			<span class="rowvalue">{{=$ctx.moneyFormatted(currency, actualMaturityAmount)}}</span>
+		</div>
+	{{#else}}
+		<div class="row">
+			<span class="longrowlabel">{{=$ctx.doI18N("label.actualMaturityAmount")}}</span>
+			<span class="rowvalue">{{=$ctx.moneyFormatted(currency, projectedMaturityAmount)}}</span>
+		</div>
+	{{/if}}
+		<div class="row">
+			<span class="longrowlabel">{{=$ctx.doI18N("label.interestcompoundevery")}}</span>
+			<span class="rowvalue">{{=interestCompoundedEvery}} month(s)</span>
 		</div>
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.tenure")}}</span>
@@ -1677,6 +1855,10 @@ $(document).ready(function() {
 		<div class="row">
 			<span class="longrowlabel">{{=$ctx.doI18N("label.interest.rate.on.maturity")}}</span>
 			<span class="rowvalue">{{=$ctx.decimal(maturityInterestRate, 4)}}%</span>
+		</div>
+		<div class="row">
+			<span class="longrowlabel">{{=$ctx.doI18N("label.interest.rate.on.preclose")}}</span>
+			<span class="rowvalue">{{=$ctx.decimal(preClosureInterestRate, 4)}}%</span>
 		</div>
 </div>
 </script>
@@ -1703,16 +1885,22 @@ $(document).ready(function() {
 
 	<table>
 		<tr>
-			<td>{{=$ctx.doI18N("form.label.deposit.product.canRenew")}}</td>
-			<td>
-				<input type="checkbox" id="renewAccount" name="renewAccount" title="" style="width: 125px;" />
-			</td>
-		</tr>	
-	
-		<tr>
 			<td>{{=$ctx.doI18N("form.label.deposit.product.deposit.amount")}}</td>
 			<td>
-			<input id="deposit" name="deposit" title="" type="text" value="{{=$ctx.decimal(actualMaturityAmount, 2)}}" style="width: 125px;" />
+			<input title="" type="text" value="{{=$ctx.decimal(deposit, 2)}}" style="width: 125px;"  disabled="disabled"/>
+			</td>
+		</tr>
+
+		<tr>
+			<td>{{=$ctx.doI18N("form.label.deposit.interest.amount")}}</td>
+			<td>
+			<input type="text" value="{{=$ctx.decimal(actualInterestAccrued, 2)}}" style="width: 125px;"  disabled="disabled"/>
+			</td>
+		</tr>
+		<tr>
+			<td>{{=$ctx.doI18N("form.label.deposit.withdraw.amount")}}</td>
+			<td>
+			<input type="text" value="{{=$ctx.decimal(availableWithdrawalAmount, 2)}}" style="width: 125px;"  disabled="disabled"/>
 			</td>
 		</tr>
 	</table>	
@@ -1730,7 +1918,7 @@ $(document).ready(function() {
 
 	<table>
 		<tr>
-			<td>{{=$ctx.doI18N("form.label.deposit.product.deposit.amount")}}</td>
+			<td>{{=$ctx.doI18N("form.label.deposit.account.interest.withdraw.amount")}}</td>
 			<td>
 			<input id="amount" name="amount" title="" type="text" value="{{=$ctx.decimal(availableInterestForWithdrawal,2)}}" style="width: 125px;" />
 			<input id="currencyCode" name="currencyCode" title="" type="text" value="{{=currency.code}}" style="width: 40px;" disabled="disabled" />
@@ -3492,7 +3680,15 @@ $(document).ready(function() {
 </script>
 
 <!-- end of admin templates -->
-
+<script type="text/javascript">
+function updateCheckbox(){
+	    var other = $('#interestCompoundingAllowed:checked').val();
+		//alert(other);
+	    if (other == undefined) $("#isInterestWithdrawable").prop("checked", true);
+	    else $("#isInterestWithdrawable").prop("checked", false);
+	
+}
+</script>
 
 </body>
 </html>

--- a/IndividualLendingGeneralJavaScript/IndivLendHome.html
+++ b/IndividualLendingGeneralJavaScript/IndivLendHome.html
@@ -981,10 +981,10 @@ $(document).ready(function() {
 						<td>
 							{{#if interestCompoundingAllowed}}
 							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" checked=checked onClick="updateCheckbox()"/><br /><br />
-							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" disabled="disabled"/>
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" />
 							{{#else}}
 							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" onClick="updateCheckbox()"/><br /><br />
-							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked disabled="disabled"/>
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked />
 							{{/if}}
 						</td>
 					</tr>
@@ -1155,10 +1155,10 @@ $(document).ready(function() {
 						<td>
 							{{#if interestCompoundingAllowed}}
 							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" checked=checked onClick="updateCheckbox()"/><br /><br />
-							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" disabled="disabled"/>
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" />
 							{{#else}}
 							<input type="checkbox" id="interestCompoundingAllowed" name="interestCompoundingAllowed" title="" style="width: 125px;" onClick="updateCheckbox()"/><br /><br />
-							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked disabled="disabled"/>
+							<input type="checkbox" id="isInterestWithdrawable" name="isInterestWithdrawable" title="" style="width: 125px;" checked=checked />
 							{{/if}}
 						</td>
 					</tr>

--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.09.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.09.js
@@ -1360,16 +1360,33 @@ function showILGroup(groupId){
 			});
     		$('button.withdrawinterestamount span').text(doI18N('label.withdraw.interest.amount'));
 
+    		
+    		$('.renewdepositaccount').button().click(function(e) {
+				var linkId = this.id;
+				var depositAccountId = linkId.replace("renewbtn", "");
+				var postUrl = 'depositaccounts/' + depositAccountId + '?command=renew';
+				var getUrl = 'depositaccounts/' + depositAccountId + '?template=true';
+				var templateSelector = "#renewDepositFormTemplate";
+				var width = 850; 
+				var height = 450;
+
+				eval(genSaveSuccessFunctionReloadDeposit(depositAccountId));
+				popupDialogWithFormView(getUrl, postUrl, 'POST', 'dialog.title.renew.deposit.account', templateSelector, width, height, saveSuccessFunctionReloadClient);
+				e.preventDefault();
+			});
+    		$('button.renewdepositaccount span').text(doI18N('label.renew.deposit.account'));
+ 
 			$('.withdrawdepositamount').button().click(function(e) {
 				var linkId = this.id;
 				var depositAccountId = linkId.replace("withdrawbtn", "");
 				var postUrl = 'depositaccounts/' + depositAccountId + '?command=withdrawal';
+				var getUrl = 'depositaccounts/' + depositAccountId + '?template=true';
 				var templateSelector = "#withdrawAmountFormTemplate";
 				var width = 400; 
 				var height = 280;
 
 				eval(genSaveSuccessFunctionReloadDeposit(depositAccountId));
-				popupDialogWithPostOnlyFormView(postUrl, 'POST', 'dialog.title.withdraw.deposit.amount', templateSelector, width, height, saveSuccessFunctionReloadDeposit);
+				popupDialogWithFormView(getUrl, postUrl, 'POST', 'dialog.title.withdraw.deposit.amount', templateSelector, width, height, saveSuccessFunctionReloadDeposit);
 			    
 				e.preventDefault();
 			});

--- a/IndividualLendingGeneralJavaScript/resources/global-translations/messages.properties
+++ b/IndividualLendingGeneralJavaScript/resources/global-translations/messages.properties
@@ -182,45 +182,59 @@ depositStatusType.closed=Closed
 depositStatusType.matured=Matured
 depositStatusType.preclosed=Preclosed
 
-label.client.account.deposit.matured.on=MaturedOn
-label.actualInterestAccrued=InterestAccured
-label.interestPaid=InterestPaid
-label.actualMaturityAmount=Total
-label.client.account.deposit.closed.on=ClosedOn
+label.client.account.deposit.matured.on=Matures on:
+label.actualInterestAccrued=Actual interest accured:
+label.interestPaid=Interest paid:
+label.actualMaturityAmount=Matured Amount:
+label.client.account.deposit.closed.on=Closed on:
 label.preClosed=Preclosed
 label.rejected=Rejected
-label.withdrawnbyclient=WithdrawnByClient
+label.withdrawnbyclient=Withdrawn by client
+label.projectedInterestAccrued=Projected interest(on maturity):
  
 
 label.commencementDate=Commencement date:
 label.deposit=Deposit:
 label.tenure=Tenure:
 label.interest.rate.on.maturity=Interest rate (on maturity):
+label.closed=Closed:
+label.matured=Matured:
 
-dialog.button.new.deposit.application=New Deposit Application
+dialog.button.new.deposit.application=New deposit application
 form.label.deposit.applicant=Applicant
-form.legend.deposit.information=Deposit Applicant Information
-form.label.deposit.externalId=ExternalId:
-form.label.deposit.product.deposit.amount=Deposit Amount:
-form.label.deposit.product.nominal.interestrate=Deposit Interest Rate:
-form.label.deposit.product.tenure=Tenure Months:
-form.label.deposit.account.interest.withdraw.amount=Interest Amount
+form.legend.deposit.information=Deposit applicant information
+form.label.deposit.externalId=External id:
+form.label.deposit.product.deposit.amount=Deposit amount:
+form.label.deposit.product.nominal.interestrate=Deposit interest rate:
+form.label.deposit.product.tenure=Tenure months:
+form.label.deposit.account.interest.withdraw.amount=Interest amount
 
 label.undo.approval=Undo approval
 dialog.title.undo.deposit.approval=Undo deposit account approval: confirmation required
 dialog.title.approve.depositAccount=Approve
 dialog.button.reject.depositAccount=Reject
-dialog.title.withdraw.deposit.amount=Withdraw Total Deposit Amount
-label.withdraw.interest.amount=Withdraw Interest
-label.withdraw.deposit.amount=WithDraw FDAmount
-dialog.title.withdraw.interest.amount=Withdraw Interest Available 
+dialog.title.withdraw.deposit.amount=Withdraw total deposit amount
+label.withdraw.interest.amount=Withdraw interest
+label.withdraw.deposit.amount=WithDraw 
+dialog.title.withdraw.interest.amount=Withdraw interest available
+form.label.deposit.interest.amount=Interest(on maturity)
+form.label.deposit.withdraw.amount=Withdraw
+dialog.title.renew.deposit.account=Renew
+label.renew.deposit.account=Renew
+label.interestcompoundevery=Interest posted every:
+label.interest.rate.on.preclose=Interest rate(on preclose):  	  
 
+error.msg.deposit.closed.failed=Account close failed, contact system admin.
+error.msg.deposit.approval.cannot.be.before.submittal.date=Commencement date should less than submittal date.
 validation.msg.deposit.account.commencementDate.cannot.be.blank=Commencement date cannot be blank.
 error.msg.desposit.account.duplicate.externalId=A deposit account with external id of {0} already exists.
-validation.msg.deposit.account.deposit.cannot.be.blank=Deposit Amount required.
-validation.msg.deposit.transition.eventDate.cannot.be.blank=The Event Date 'On' cannot blank.
-validation.msg.deposit.transition.commencementDate.cannot.be.blank= The Commencement Date cannot be blank.
-deposit.transaction.interest.withdrawal.exception=Amount should greater than 0 or Enter valid amount .
+validation.msg.deposit.account.deposit.cannot.be.blank=Deposit amount required.
+validation.msg.deposit.transition.eventDate.cannot.be.blank=The event date 'On' cannot blank.
+validation.msg.deposit.transition.commencementDate.cannot.be.blank= The commencement date cannot be blank.
+deposit.transaction.interest.withdrawal.exception=Amount should greater than 0 or Enter valid amount.
+error.msg.depositaccount.cannot.reopen.before.mature=You can not renew the preclosed account.
+error.msg.deposit.account.deposit.amount.outside.of.allowed.range=The deposit amount should lessthan max deposit amount.
+
 # notes 
 widget.notes.heading=You have the following notes:
 widget.notes.label.client.note=Client note:


### PR DESCRIPTION
1. Withdraw: (Done)
   a. Interest should be computed and display in the withdraw amount option. - done
   b. Interest & FD values should be computed separately and non-editable - done
   c. FD & Interest amount should be non-editable if customer wants to withdraw before the maturity date - done
   d. Interest rate on pre-closure - done
   
   e. After interest withdraw when user goes to perform pre-closure the interest should be computed based on the withdrawn interest.
2. Renew (done)
   a. Renew should be a separate option and should not be allowed in withdraw.
   b. Renew should happen for the FD account with the parameters selected for that customer FD.
   c. Enable all the deposit terms of the FD account which were selected while creating a FD account.
   d. Commencement date should be the matured date of previous FD
   e. Total Deposit amount should be allowed for Renew (Compute Interest withdrawls while displaying total deposit amount)
