### PR TITLE
Adding document management facilities for loans

### DIFF
--- a/IndividualLendingGeneralJavaScript/IndivLendHome.html
+++ b/IndividualLendingGeneralJavaScript/IndivLendHome.html
@@ -2545,6 +2545,7 @@ $(document).ready(function() {
 		{{#if transactions}}
 		<li><a href="#transactions{{=id}}" title="transactions">{{=$ctx.doI18N("tab.client.account.loan.transactions")}}</a></li>
 		{{/if}}
+		<li><a href="#loanDocuments{{=id}}" title="documents">{{=$ctx.doI18N("tab.client.account.loan.documents")}}</a></li>
 	</ul>
     <!-- first loan tab -->
 
@@ -2909,7 +2910,105 @@ $(document).ready(function() {
 		</table>
 	</div>
 	{{/if}}
+	<!-- Loan Documents Tab--->
+	<div id="loanDocuments{{=id}}" style="margin-top: 5px;">
+		
+	</div>
+	
 </div>
+</script>
+
+<script id="loanDocumentsTemplate" type="text/x-jquery-tmpl">
+	<span id="toolbar" class="ui-widget-header ui-corner-all">
+   			<button id="addloandocument{{=loanId}}">{{=$ctx.doI18N("loan.document.add")}}</button>
+	</span>
+	<hr/>
+	<table style="vertical-align: top;width: 100%">
+		{{#each crudRows}}
+				<tr>
+					<td>{{=$ctx.doI18N("loan.document.name")}}</td>
+					<td>{{=name}}</td>
+				</tr>
+				<tr>
+				   	<td><label for="description">{{=$ctx.doI18N("loan.document.description")}}</label></td>
+					<td><textarea readonly="true" id="description" name="description" cols="75" rows="5">{{=description}}</textarea></td>
+					<td>
+						<span id="modifycellToolbar" class="ui-widget-header ui-corner-all">
+							<button id="downloadloandocument{{=id}}">{{=$ctx.doI18N("loan.document.download")}}</button>
+					   		<button id="editloandocument{{=id}}">{{=$ctx.doI18N("loan.document.edit")}}</button>
+					   		<button id="deleteloandocument{{=id}}">{{=$ctx.doI18N("loan.document.delete")}}</button>
+						</span>
+					</td>
+				</tr>
+				<tr>
+					<td>{{=$ctx.doI18N("loan.document.file.name")}}</td>
+					<td>{{=fileName}}</td>
+				</tr>
+				<tr>
+					<td colspan="2">
+						<hr/>
+					</td>
+				</tr>
+		{{/each}}
+	</table>
+</script>
+
+<script id="loanDocumentsFormTemplate" type="text/x-jquery-tmpl">
+<form id="entityform" >
+    <div id="formerrors"></div>
+	<table>
+		<tr>
+			<td>
+				<label for="name">{{=$ctx.doI18N("loan.document.name")}}</label>
+				<input id="name" name="name" title="" type="text" value="{{=name}}"/>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<label for="description">{{=$ctx.doI18N("loan.document.description")}}</label>
+				<textarea cols="75" rows="5" id="description" name="description">{{=description}}</textarea>
+			</td>
+		<tr>
+		<tr>
+			<td colspan="2" valign="top">
+				<label for="file">{{=$ctx.doI18N("loan.document.file.select")}}</label>
+				<input type="file" name="file" id="file" size="65"></input>
+			</td>
+		</tr>
+	</table>
+ </form>
+</script>
+
+<script id="editLoanDocumentsFormTemplate" type="text/x-jquery-tmpl">
+<form id="entityform" >
+    <div id="formerrors"></div>
+	<table>
+		<tr>
+			<td>
+				<label for="name">{{=$ctx.doI18N("loan.document.name")}}</label>
+				<input id="name" name="name" title="" type="text" value="{{=name}}"/>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<label for="description">{{=$ctx.doI18N("loan.document.description")}}</label>
+				<textarea cols="75" rows="5" id="description" name="description">{{=description}}</textarea>
+			</td>
+		<tr>
+		<tr>
+			<td>
+				<label for="description">{{=$ctx.doI18N("loan.document.current.file.name")}}</label>
+				{{=fileName}}
+			</td>
+		<tr>
+		<tr>
+			<td colspan="2" valign="top">
+				<label for="file">{{=$ctx.doI18N("loan.document.file.new.select")}}</label>
+				<input type="file" name="file" id="file" size="65"></input>
+			</td>
+		</tr>
+	</table>
+ </form>
 </script>
 
 <script id="stateTransitionLoanFormTemplate" type="text/x-jquery-tmpl">

--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.09.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.09.js
@@ -1857,7 +1857,12 @@ function loadILLoan(loanId) {
 						"show": function(event, ui) {
 							var curTab = $('#newtabs .ui-tabs-panel:not(.ui-tabs-hide)');
 			      			var curTabID = curTab.prop("id")
-						}
+						},
+						"select": function( event, ui ) {
+        					if($(ui.panel).attr( 'id' ) == ( "loanDocuments"+ loanId )){
+        						refreshLoanDocuments(loanId)
+        					}
+   						}
 					});
 	        		
 	        		$('.rejectloan').button().click(function(e) {
@@ -2122,6 +2127,73 @@ function loadILLoan(loanId) {
 
 }
 
+
+function refreshLoanDocuments(loanId) {
+		var successFunction =  function(data, textStatus, jqXHR) {
+			var crudObject = new Object();
+			crudObject.crudRows = data;
+			crudObject.loanId	= loanId;
+			var tableHtml = $("#loanDocumentsTemplate").render(crudObject);
+			$("#loanDocuments"+loanId).html(tableHtml);
+			//initialize all edit/delete buttons
+			var loanUrl = "loans/"+ loanId;
+			var editLoanDocumentSuccessFunction = function(data, textStatus, jqXHR) {
+			  	$("#dialog-form").dialog("close");
+			  	refreshLoanDocuments(loanId);
+			}
+			$.each(crudObject.crudRows, function(i, val) {
+			      $("#editloandocument" + val.id).button({icons: {
+	                primary: "ui-icon-pencil"}}
+	                ).click(function(e){
+			      	
+					var getUrl = loanUrl + '/documents/'+val.id;
+					var putUrl = loanUrl + '/documents/'+val.id;
+					var templateSelector = "#editLoanDocumentsFormTemplate";
+					var width = 600; 
+					var height = 450;
+					popupDialogWithFormView(getUrl, putUrl, 'PUT', "dialog.title.edit.group", templateSelector, width, height,  editLoanDocumentSuccessFunction);
+				    e.preventDefault();
+			      });
+			      $("#deleteloandocument" + val.id).button({icons: {
+	                primary: "ui-icon-circle-close"}
+	            	}).click(function(e) {
+					var url = loanUrl + '/documents/'+val.id;
+					var width = 400; 
+					var height = 225;
+											
+					popupConfirmationDialogAndPost(url, 'DELETE', 'dialog.title.confirmation.required', width, height, 0, editLoanDocumentSuccessFunction);
+					
+					e.preventDefault();
+				});
+				$("#downloadloandocument" + val.id).button({icons: {
+	                primary: "ui-icon-arrowthickstop-1-s"}
+	            	}).click(function(e) {
+					var url = loanUrl + '/documents/'+val.id + '/attachment';
+					executeAjaxOctetStreamDownloadRequest(url);
+					e.preventDefault();
+				});
+			});			
+			//associate event with add loan document button
+			$('#addloandocument'+loanId).button({icons: {
+	                primary: "ui-icon-plusthick"}
+	            	}).click(function(e) {
+				var getUrl = "";
+				var putUrl = loanUrl + '/documents';
+				var templateSelector = "#loanDocumentsFormTemplate";
+				var width = 600; 
+				var height = 450;
+				
+				var saveSuccessFunction = function(data, textStatus, jqXHR) {
+				  	$("#dialog-form").dialog("close");
+				  	refreshLoanDocuments(loanId);
+				}
+				
+				popupDialogWithFormView(getUrl, putUrl, 'POST', "dialog.title.edit.group", templateSelector, width, height,  saveSuccessFunction);
+			    e.preventDefault();
+			});
+		}
+  		executeAjaxRequest("loans/"+ loanId + '/documents', 'GET', "", successFunction, formErrorFunction);	  	
+}
 
 /* crud admin code */
 

--- a/IndividualLendingGeneralJavaScript/resources/global-translations/messages.properties
+++ b/IndividualLendingGeneralJavaScript/resources/global-translations/messages.properties
@@ -362,6 +362,7 @@ tab.client.account.loan.details=Details
 tab.charges=Charges
 tab.client.account.loan.schedule=Schedule
 tab.client.account.loan.transactions=Transactions
+tab.client.account.loan.documents=Document(s)
 
 tab.client.account.loan.schedule.table.summary.caption=Summary
 tab.client.account.loan.schedule.table.repaymentschedule.caption=Repayment Schedule
@@ -868,3 +869,16 @@ client.document.file.new.select= Select a new File:
 client.document.download= Download:
 validation.msg.document.fileName.cannot.be.blank= Please select a file
 validation.msg.document.name.cannot.be.blank= Please enter the name for the document
+
+#Loan Documents
+loan.document.tab.name= Loan Document(s)
+loan.document.add=Add a Document
+loan.document.name=Name:
+loan.document.description=Description
+loan.document.edit=Edit:
+loan.document.delete=Delete:
+loan.document.file.select=Browse the file to upload:
+loan.document.file.name= File name:
+loan.document.current.file.name= Current File name:
+loan.document.file.new.select= Select a new File:
+loan.document.download= Download:


### PR DESCRIPTION
Keith, 

There is a known issue with this commit:

When a user opens the same loan in two separate jquery tabs (by clicking on the loan link twice in user summary tab) the document management tab would work only for the first tab 

However it does work as expected when multiple loan products are opened in separate jquery tabs etc.

I was thinking instead of fixing this issue, would it be better if  I raised a separate bug on Jira and not allow opening multiple loan tabs for the same loan when a user clicks on them in the summary tab (simply refresh the existing tab instead)

What would you advise?
