### PR TITLE
review comments incorporated

### DIFF
--- a/IndividualLendingGeneralJavaScript/IndivLendHome.html
+++ b/IndividualLendingGeneralJavaScript/IndivLendHome.html
@@ -936,7 +936,7 @@ $(document).ready(function() {
 <script id="groupHierarchyTemplate" type="text/x-jquery-tmpl">
 	<ul>
 		{{#each crudRows}}
-			<li><a href="#" class="addgroup" onClick="addGroup({{=id}});">{{=$ctx.doI18N("label.group.manage.create.new")}}{{=levelName}}</a></li>
+			<li><a href="#" class="addgroup" onClick="addGroup({{=levelId}});">{{=$ctx.doI18N("label.group.manage.create")}}&nbsp;{{=levelName}}</a></li>
 		{{/each}}
 	</ul>	
 </script>
@@ -1223,8 +1223,13 @@ $(document).ready(function() {
 			<div>
 				<label for="parent">{{=$ctx.doI18N("label.group.parent")}}</label>
 				<select id="parentId" name="parentId" title="">
+                    <option value="">{{=$ctx.doI18N("option.group.select.parent.first.choice")}}</option>
 					{{#each allowedParentGroups}}
-							<option value="{{=$ctx.number(id)}}">{{=name}}</option>
+                        {{#if $ctx.number($parent.parent.data.parentId)===$ctx.number(id)}}
+                            <option value="{{=$ctx.number(id)}}" selected="selected">{{=name}}</option>
+                        {{#else}}
+                            <option value="{{=$ctx.number(id)}}">{{=name}}</option>
+                        {{/if}}                            
 					{{/each}}
 				</select>
 				</div>
@@ -1235,8 +1240,13 @@ $(document).ready(function() {
 			<td colspan="2">
 				<label for="staffs">{{=$ctx.doI18N("label.group.staff")}}</label>
 				<select id="staffId" name="staffId" title="">
-					{{#each allowedStaffs}}
-							<option value="{{=$ctx.number(id)}}">{{=displayName}}</option>
+                    <option value="">{{=$ctx.doI18N("option.group.select.staff.first.choice")}}</option>
+                    {{#each allowedStaffs}}
+                        {{#if $ctx.number($parent.parent.data.staffId)===$ctx.number(id)}}
+                            <option value="{{=$ctx.number(id)}}" selected="selected">{{=displayName}}</option>
+                        {{#else}}
+                            <option value="{{=$ctx.number(id)}}">{{=displayName}}</option>
+                        {{/if}}                              
 					{{/each}}
 				</select>
 			</td>

--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.3.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.3.js
@@ -1617,8 +1617,13 @@ function addGroup(levelid , parentGroupId) {
 		var templateSelector = "#groupFormTemplate";
 		var width = 900; 
 		var height = 500;
+		var title = 'dialog.title.add.grouping.at.level.' + levelid ;
 		
-		popupDialogWithFormView(getUrl, postUrl, 'POST', 'dialog.title.add.group', templateSelector, width, height, addGroupSuccessFunction , parentGroupId);
+		if(!(parentGroupId === undefined)){
+			var extraParam = '{"action":"disable"'  + ' , "parentGroupId":"'+ parentGroupId +'"}';
+		}
+
+		popupDialogWithFormView(getUrl, postUrl, 'POST', title , templateSelector, width, height, addGroupSuccessFunction , extraParam);
 		
 	    e.preventDefault();
 }
@@ -1626,7 +1631,6 @@ function addGroup(levelid , parentGroupId) {
 // Add New Client 
 function addClient(officeId, parentGroupId){
 
-		var extraParam = '{"officeId":"'+ officeId + '" , "groupId":"'+ parentGroupId +'"}';
 
 		var addClientSuccessFunction = function(data, textStatus, jqXHR) {
 		  $('#dialog-form').dialog("close");
@@ -1639,6 +1643,7 @@ function addClient(officeId, parentGroupId){
 		var width = 600; 
 		var height = 350;
 		
+		var extraParam = '{"officeId":"'+ officeId + '" , "groupId":"'+ parentGroupId +'"}';
 		popupDialogWithFormView(getUrl, postUrl, 'POST', 'dialog.title.add.client', templateSelector, width, height, addClientSuccessFunction , extraParam);
 
 }
@@ -2481,7 +2486,9 @@ function showILGroup(groupId){
 				  	showILGroup(groupId);
 				}
 				
-				popupDialogWithFormView(getUrl, putUrl, 'PUT', "dialog.title.edit.group", templateSelector, width, height,  saveSuccessFunction);
+				var title = 'dialog.title.edit.grouping.at.level.' + data.groupLevelData.levelId;
+
+				popupDialogWithFormView(getUrl, putUrl, 'PUT', title, templateSelector, width, height,  saveSuccessFunction , extraParam);
 			    e.preventDefault();
 			});
 
@@ -5153,7 +5160,7 @@ function popupDialogWithFormView(getUrl, postUrl, submitType, titleCode, templat
 		  		}
 		  		
 				// When create Client is invoked from parent group profile 
-				// set  parentGroup and Office by defualt and make is un-editable
+				// set  parentGroup and Office by default and make it un-editable
 
 				if (templateSelector == "#clientFormTemplate") 
 				{
@@ -5165,20 +5172,29 @@ function popupDialogWithFormView(getUrl, postUrl, submitType, titleCode, templat
 							$('#officeId').prop('disabled', true);
 							$('<input>').attr({type: 'hidden',id: 'officeId',name: 'officeId',value:officeId}).appendTo('#entityform');
 							$('<input>').attr({type: 'hidden',id: 'groupId',name: 'groupId',value:groupId}).appendTo('#entityform');
-
-
 						}	
 				}
 
 				if (templateSelector == "#groupFormTemplate") 
 				{
-					
-					$('#officeId').prop('disabled', true);
 
-					if(!(extraParam === undefined) ){
-						$('#parentId').prop('disabled', true);
-						$('<input>').attr({type: 'hidden',id: 'parentId',name: 'parentId',value:extraParam}).appendTo('#entityform');
-					}	
+					// Scenario 1: For creating new group from quick link extraParam will be undefined
+					// Scenario 2: For creating new group from parent group extraParam will be defined and disable selecting parent group
+					// Scenario 3: For editing group extraParam will be undefined
+
+					if(!(extraParam === undefined)){
+						var groupId = jQuery.parseJSON(extraParam).parentGroupId;
+						var action = jQuery.parseJSON(extraParam).action;
+						$('#officeId').prop('disabled', true);
+						if(!(groupId === undefined) ){
+							$("#parentId option[value='"+ groupId +"']").attr("selected", "selected");
+							if(action == 'disable'){
+								$('#parentId').prop('disabled', true);
+								$('<input>').attr({type: 'hidden',id: 'parentId',name: 'parentId',value:groupId}).appendTo('#entityform');
+
+							}
+						}	
+					}
 				}
 				//End group create specific code
 

--- a/IndividualLendingGeneralJavaScript/resources/global-translations/messages-groups.properties
+++ b/IndividualLendingGeneralJavaScript/resources/global-translations/messages-groups.properties
@@ -1,28 +1,24 @@
 ﻿#Translations of Error and Validation messages returned from mifos platform API for group features
 
 # groups resource /groups
-error.msg.group.duplicate.externalId=Group with that external id already exists.
 error.msg.client.attach.to.group.invalid.office=The group and its client's must belong to the same office.
-validation.msg.group.name.cannot.be.blank=Name is mandatory.
-validation.msg.group.clientMembers.cannot.be.empty=A group must contain at least one client.
+validation.msg.group.name.cannot.be.blank=Name is mandatory.ust contain at least one client.
 validation.msg.group.officeId.cannot.be.blank=Office is mandatory.
 
 ####
 # Groups screens
 ###
+tab.search.group.title=<=== Search for Groups(by name) Or View All Available Groups ===>
+tab.group.manage=Manage Centers & Groups
 
 label.clients=Clients(??xxxx??)
-
-# Groups search screen
-tab.search.group.title=<=== Search for Groups(by name) Or View All Available Groups ===>
-tab.group.manage=Manage Groups
-label.group.manage=Manage Groups
-label.group.manage.create.new=Create new
+label.group.manage=Manage Centers & Groups
+label.group.manage.create=Create
 label.group.search.by.name=Search for groups by name:
 label.group.search=Choose group:
 label.group.name=Group name:
 label.group.externalid=External id:
-label.groups=Groups
+label.groups=Centers & Groups
 label.group.toggle.member.loan.details=Toggle Details
 label.group.parent=Parent
 label.group.staff=Staff:
@@ -54,10 +50,10 @@ label.group.offices=Offices
 label.group.client.tasks=Clients & Groups Tasks
 
 option.group.search.first.choice=--Select Group--
+option.group.select.parent.first.choice=--Select Parent--
+option.group.select.staff.first.choice=--Select Staff--
 link.add.new.group=Add a new group
 
-dialog.title.add.group=Add group
-dialog.title.edit.group=Edit group
 form.label.group.name=Name:
 form.label.group.externalid=External id:
 form.label.group.available.clients=Available clients:
@@ -72,3 +68,20 @@ button.group.search=Search
 #group screen
 heading.group.account.loanaccount.overview=Loan Accounts Overview
 heading.group.account.individual.loanaccount.overview=Individual Loan Accounts Overview
+
+
+#
+## Need hierarchization
+#
+
+# error
+error.msg.group.duplicate.externalId=Group with that external id already exists.
+error.msg.center.duplicate.externalId=Center with that external id already exists.
+error.msg.group.duplicate.name=Group with that name id already exists.
+error.msg.center.duplicate.name=Center with that name id already exists.
+
+# dialog
+dialog.title.add.grouping.at.level.1=Create Center
+dialog.title.add.grouping.at.level.2=Create Group
+dialog.title.edit.grouping.at.level.1=Edit Center
+dialog.title.edit.grouping.at.level.2=Edit Group


### PR DESCRIPTION
Hi Keith,

Updates are as follow

UI corrections
- [x] Guess text should be 'Manage centers & groups'
- [x] Data scoping: groups api for returning list of 'groups' isnt data scoped by user like offices is.
- [x] Group Search:
      - Data scoping: groups api for returning list of 'groups' isnt data scoped by user like offices is.
- [x] Create new Center workflow:
      - Menu item text: 'Create newCenter' should be 'Create Center'
      - Center dialog: title is 'Add group' rather than 'Create Center:'
      - Staff associated with center can be option but theres no -- Select option so auto defaults to first staff option
      - validation: Able to create a center with blank name
      - Validation: entering a really long name results in 'error.msg.group.duplicate.name' error message
      - Validation: Creating center with same name as another center results in 'error.msg.group.duplicate.name' error message
      - Validation: Creating center with same external id correctly shows error but gives error message of 'Group' already exists
- [x] Edit screen:
  - Center dialog: title is 'Edit group' rather than 'Edit Center:'
  - Same validation issues as with create center workflow
- [x] Add Group to center workflow:
  - Able to create group with no name

Create new Group workflow:
- [x] - Creating a group must have a parent as dropdown option has no
      '--Select--' option
      - Creating group with same external id as a 'center' results in
          duplicate entry (key should include the type I guess)
- [x] Edit Screen:
      - Unable to unset the parent of a group (take group out of center-group hierarchy)

Thanks
Nayan Ambali
