### PR TITLE
changes to syn checkboxes in new loan application

### DIFF
--- a/IndividualLendingGeneralJavaScript/IndivLendHome.html
+++ b/IndividualLendingGeneralJavaScript/IndivLendHome.html
@@ -9252,6 +9252,7 @@ $(document).ready(function() {
 			<input type="checkbox" id="syncDisbursementWithMeeting" name="syncDisbursementWithMeeting"/>
 			<label for="syncDisbursementWithMeeting" style="display: inline">{{=$ctx.doI18N("label.meeting.calendar.syncDisbursement")}}</label>
 		</div>
+		<span id="uncheckSyncRepayment" style="background-color:#F2F5A9"></span>
 		<hr>
 	{{/each}}
 </script>
@@ -10642,6 +10643,9 @@ $(document).ready(function() {
 <script id="codeValueErrorDialogFormTemplate" type="text/x-jquery-tmpl">
 	<span class="ui-icon ui-icon-alert floatleft" style="margin: 0 7px 20px 0;"></span> 
 	{{=$ctx.doI18N("error.msg.codeValue.in.use")}}
+</script>
+<script id="msgLoanSyncCheckbox" type="text/x-jquery-tmpl">
+	{{=$ctx.doI18N("msg.checkSynRepayment.mandatory.show")}}
 </script>
 </body>
 </html>

--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.4.0.RELEASE.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.4.0.RELEASE.js
@@ -9138,6 +9138,22 @@ function loadAvailableCalendars(allAttachedCalendars, meetingCalendar, loanId, s
     calendars.crudRows = allAttachedCalendars;
     var tableHtml = $('#meetingCalendarTemplate').render(calendars);
     $('#meetingCalendarPlaceholder').html(tableHtml);
+
+    $('#syncRepaymentsWithMeeting').change(function(){
+		if((!$(this).is(':checked')) && ($('#syncDisbursementWithMeeting').is(':checked'))){
+	    	$('input:checkbox[id=syncDisbursementWithMeeting]').prop('checked', false);
+	    	var msgHtml = $("#msgLoanSyncCheckbox").render();
+	    	$("#uncheckSyncRepayment").html(msgHtml).show().delay(4000).fadeOut(300);
+    	}
+    });
+
+    $('#syncDisbursementWithMeeting').change(function(){
+		if($(this).is(':checked') && !$('#syncRepaymentsWithMeeting').is(':checked')){
+			$('input:checkbox[id=syncRepaymentsWithMeeting]').prop('checked', true);
+			var msgHtml = $("#msgLoanSyncCheckbox").render();
+			$("#uncheckSyncRepayment").html(msgHtml).show().delay(4000).fadeOut(300);
+    	}
+    });
     
     if(!meetingCalendar && !loanId){ 
 		//If meeting is null and loanId is null then syncRepayment should be checked
@@ -9151,6 +9167,7 @@ function loadAvailableCalendars(allAttachedCalendars, meetingCalendar, loanId, s
 		if(meetingCalendar){
 			$('input:checkbox[id=syncRepaymentsWithMeeting]').prop('checked', true);
 		}
+
 	}
 
     var getAttachedCalendarData = function(){

--- a/IndividualLendingGeneralJavaScript/resources/global-translations/messages.properties
+++ b/IndividualLendingGeneralJavaScript/resources/global-translations/messages.properties
@@ -1032,6 +1032,7 @@ lable.meeting.type.option.collection=Collection meeting
 lable.meeting.type.option.training=Training meeting
 lable.meeting.type.option.audit=Audit meeting
 lable.meeting.type.option.general=General meeting
+msg.checkSynRepayment.mandatory.show=Sync disbursement date with meeting cannot be selected without selecting Sync repayments with meeting.
 
 #Collection sheet
 tab.collection.sheet=Collection Sheet


### PR DESCRIPTION
What changes i made is "Sync repayments with meeting" is mandatory to select "Sync disbursement date with meeting".
When "Sync disbursement date with meeting " checkbox is checked,  "Sync repayments with meeting"also checked.
When " Sync repayments with meeting" checkbox is unchecked , "Sync disbursement date with meeting" also unchecked.
