### PR TITLE
view holiday display on screen fixed

### DIFF
--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.5.0.RELEASE.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.5.0.RELEASE.js
@@ -9927,6 +9927,7 @@ function loadCollectionSheet(postUrl){
 
 function addHoliday() {
 
+	setOrgAdminContent('content');
 	var officeSearchSuccessFunction =  function(data) {
 		var finalJson = [];
 		
@@ -10126,6 +10127,7 @@ function launchProductMixDialog(loanProductId) {
 
 function listHolidays() {
 
+	setOrgAdminContent('content');
 	var officeSearchSuccessFunction =  function(data) {
 		var officeSearchObject = new Object();
 	    officeSearchObject.crudRows = data;


### PR DESCRIPTION
click on "add holiday/loanproduct/accountingrule..." , then click on "view holidays" (issue MIFOSX-550)  screen is not showing properly, and in  "add holiday" dates are not able to select .
