### PR TITLE
calendarId will be passed to api only when syn repay/disbur checkbox selected

### DIFF
--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.6.0.RELEASE.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.6.0.RELEASE.js
@@ -4037,6 +4037,10 @@ function showCenter(centerId){
             serializedArray["calendarId"] = $("#calendarId").val();
         }
 
+        if (!$('#syncRepaymentsWithMeeting').is(':checked') && !$('#syncDisbursementWithMeeting').is(':checked')) {
+        	delete serializedArray["calendarId"];
+        }
+
 		var newFormData = JSON.stringify(serializedArray);
 
 		var successFunction =  function(data, textStatus, jqXHR) {
@@ -4076,6 +4080,10 @@ function showCenter(centerId){
         if(!(group === undefined)){
             serializedArray["groupId"] = group.id;//This is group loan
             serializedArray["calendarId"] = $("#calendarId").val();
+        }
+
+        if (!$('#syncRepaymentsWithMeeting').is(':checked') && !$('#syncDisbursementWithMeeting').is(':checked')) {
+        	delete serializedArray["calendarId"];
         }
 
 		var newFormData = JSON.stringify(serializedArray);
@@ -4434,7 +4442,7 @@ function showCenter(centerId){
 		serializedArray = $('#entityform').serializeObject(serializationOptions);
 
 		if(!$("#syncRepaymentsWithMeeting").is(':checked') && !$("#syncDisbursementWithMeeting").is(':checked')){
-			serializedArray["calendarId"] = "";	
+			delete serializedArray["calendarId"];	
 		}
 
 		var newFormData = JSON.stringify(serializedArray);


### PR DESCRIPTION
In changes deleting "calendarId" when both "Sync repayments with meeting"/"Sync disbursement date with meeting"
is  in unchecked state.
