### PR TITLE
URGENT Fix for "Cannot read property 'name' of undefined." (AKA "$data.template is undefined.")

### DIFF
--- a/IndividualLendingGeneralJavaScript/IndivLendHome.html
+++ b/IndividualLendingGeneralJavaScript/IndivLendHome.html
@@ -1486,7 +1486,7 @@ $(document).ready(function() {
 		{{#each clientDocuments}}
 		<tr>
 			<td>
-				<a href="#" onclick="createClientDocumentForTemplate('{{=template.name}}',{{=template.id}}, {{=$parent.parent.data.clientId}});">{{=template.name}}</a>
+				<a href="#" onclick="createClientDocumentForTemplate('{{=name}}',{{=id}}, {{=$parent.parent.data.clientId}});">{{=name}}</a>
 			</td>
 		</tr>
 		{{/each}}


### PR DESCRIPTION
Hi guys, 

this patch (which is actually from Andreas, I had it in email; no idea why he hadn't pushed this to you yet) fixes the  "Cannot read property 'name' of undefined." (AKA "$data.template is undefined.") bug that currently shows up on the 'Template Documents' tab for Loan and Client.

I would be grateful if you could pull & integrate this ASAP and update https://demo.openmf.org/?&mode=dev# with it (that's probably automatic) - this would enable us to demo UGD more easily e.g. for the video I'm planning to make as well as for the upcoming Mifos summit.

Thank you!
