### PR TITLE
Fix for broken  Template Documents tab on Loan UI

### DIFF
--- a/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.11.0.RELEASE.js
+++ b/IndividualLendingGeneralJavaScript/resources/IndividualLendingCode-1.11.0.RELEASE.js
@@ -3823,7 +3823,7 @@ function refreshClientTemplates(clientUrl) {
 }
 
 function formatDateTags() {
-	
+
 	var dateTags = document.getElementsByTagName('date');
 	
 	for( i=0; i<dateTags.length; i++ ) {
@@ -3840,9 +3840,16 @@ function formatDateTags() {
 }
 
 function createClientDocumentForTemplate(title, templateId, clientId) {
-	
 	var content = executeSynchroneAjaxRequest('templates/'+templateId+'?clientId='+clientId, "POST", "{}", null, null);
-	
+	openDocumentForTemplate(title, content)
+}
+
+function createLoanDocumentForTemplate(title, templateId, loanId) {
+	var content = executeSynchroneAjaxRequest('templates/'+templateId+'?loanId='+loanId, "POST", "{}", null, null);
+	openDocumentForTemplate(title, content)
+}
+
+function openDocumentForTemplate(title, content) {
 	var dialogDiv = $("<div id='dialog-form'></div>");
 	dialogDiv.html(content);
 	


### PR DESCRIPTION
similarly to https://github.com/openMF/mifosx-community-apps/pull/406 for Client, the UGD tab on Loan was also broken.. not with the same JS, the templates ARE listed on the tab, but clicking on them leads to a missing function error (which this fixes).

I would be grateful if you could pull & integrate this ASAP and update https://demo.openmf.org/?&mode=dev# with it (that's probably automatic) - this would enable us to demo UGD more easily e.g. at the upcoming Mifos summit.

Thank you!
